### PR TITLE
Update for Rails6 / RailsAdmin2

### DIFF
--- a/lib/rails_admin_material/version.rb
+++ b/lib/rails_admin_material/version.rb
@@ -1,3 +1,3 @@
 module RailsAdminMaterial
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/vendor/assets/stylesheets/rails_admin/themes/material/variables.scss
+++ b/vendor/assets/stylesheets/rails_admin/themes/material/variables.scss
@@ -6,7 +6,31 @@
 @import 'bootstrap-material-design/_mixins';
 @import 'bootstrap-material-design/_shadows';
 @import 'bootstrap-material-design/_form';
-@import 'bootstrap-material-design/**/*';
+// @import 'bootstrap-material-design/**/*'; // not working with Rails6 + RailsAdmin2
+
+@import 'bootstrap-material-design/_core';
+@import 'bootstrap-material-design/_alerts';
+@import 'bootstrap-material-design/_buttons';
+@import 'bootstrap-material-design/_cards';
+@import 'bootstrap-material-design/_checkboxes';
+@import 'bootstrap-material-design/_colors';
+@import 'bootstrap-material-design/_colors-map';
+@import 'bootstrap-material-design/_dialogs';
+@import 'bootstrap-material-design/_dividers';
+@import 'bootstrap-material-design/_inputs';
+@import 'bootstrap-material-design/_inputs-size';
+@import 'bootstrap-material-design/_labels';
+@import 'bootstrap-material-design/_lists';
+@import 'bootstrap-material-design/_navbar';
+@import 'bootstrap-material-design/_panels';
+@import 'bootstrap-material-design/_popups';
+@import 'bootstrap-material-design/_progress';
+@import 'bootstrap-material-design/_radios';
+@import 'bootstrap-material-design/_shadows';
+@import 'bootstrap-material-design/_tabs';
+@import 'bootstrap-material-design/_togglebutton';
+@import 'bootstrap-material-design/_typography';
+@import 'bootstrap-material-design/_welljumbo';
 
 // fonts
 $admin-font: 'Roboto', sans-serif;

--- a/vendor/assets/stylesheets/rails_admin/themes/material/variables.scss
+++ b/vendor/assets/stylesheets/rails_admin/themes/material/variables.scss
@@ -7,30 +7,11 @@
 @import 'bootstrap-material-design/_shadows';
 @import 'bootstrap-material-design/_form';
 // @import 'bootstrap-material-design/**/*'; // not working with Rails6 + RailsAdmin2
-
-@import 'bootstrap-material-design/_core';
-@import 'bootstrap-material-design/_alerts';
-@import 'bootstrap-material-design/_buttons';
-@import 'bootstrap-material-design/_cards';
-@import 'bootstrap-material-design/_checkboxes';
+@import 'bootstrap-material-design/_core'; // this updates most of the other partials
 @import 'bootstrap-material-design/_colors';
 @import 'bootstrap-material-design/_colors-map';
-@import 'bootstrap-material-design/_dialogs';
-@import 'bootstrap-material-design/_dividers';
-@import 'bootstrap-material-design/_inputs';
-@import 'bootstrap-material-design/_inputs-size';
 @import 'bootstrap-material-design/_labels';
-@import 'bootstrap-material-design/_lists';
-@import 'bootstrap-material-design/_navbar';
-@import 'bootstrap-material-design/_panels';
-@import 'bootstrap-material-design/_popups';
-@import 'bootstrap-material-design/_progress';
-@import 'bootstrap-material-design/_radios';
 @import 'bootstrap-material-design/_shadows';
-@import 'bootstrap-material-design/_tabs';
-@import 'bootstrap-material-design/_togglebutton';
-@import 'bootstrap-material-design/_typography';
-@import 'bootstrap-material-design/_welljumbo';
 
 // fonts
 $admin-font: 'Roboto', sans-serif;


### PR DESCRIPTION
RA is blowing up on this line

`@import 'bootstrap-material-design/**/*';
`

I couldn't figure out if it's a Rails6/Sprockets or RailsAdmin2 or SassC problem, but importing the partials explicitly lets it work again for me.